### PR TITLE
use CALayer for macOS backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ x11-dl = "2.19.1"
 winapi = "0.3.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.24.0"
 core-graphics = "0.22.3"
+foreign-types = "0.3.0"
 objc = "0.2.7"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -7,7 +7,7 @@ use core_graphics::geometry::CGSize;
 use core_graphics::image::CGImage;
 
 use cocoa::base::id;
-use cocoa::quartzcore::CALayer;
+use cocoa::quartzcore::{CALayer, ContentsGravity};
 use foreign_types::ForeignType;
 
 pub struct CGImpl {
@@ -18,6 +18,7 @@ impl CGImpl {
     pub unsafe fn new<W: HasRawWindowHandle>(handle: AppKitHandle) -> Result<Self, SoftBufferError<W>> {
         let view = handle.ns_view as id;
         let layer = CALayer::new();
+        layer.set_contents_gravity(ContentsGravity::TopLeft);
         let _: () = msg_send![view, setLayer:layer.clone()];
         Ok(Self{layer})
     }


### PR DESCRIPTION
This should fix: https://github.com/rust-windowing/winit/pull/2189 and https://github.com/rust-windowing/winit/issues/1605

As you're already constructing a `CGImage`, you can create an `NSImage` backed by it using `NSCGImageRep`

You can set your `view.layer` to a new `CALayer`, and repeatedly set `layer.contents` to the new `NSImage` instead of trying to draw to the `NSView` directly.

This approach works whether or not you're called from a draw callback, and does not require any changes to `winit`.