### PR TITLE
Add `impl AsRef<W> for GraphicsContext<W>`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ impl<W: HasRawWindowHandle> GraphicsContext<W> {
 
 impl<W: HasRawWindowHandle> AsRef<W> for GraphicsContext<W> {
     /// Equivalent to [`self.window()`](Self::window()).
+    #[inline]
     fn as_ref(&self) -> &W {
         self.window()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,13 @@ impl<W: HasRawWindowHandle> GraphicsContext<W> {
     }
 }
 
+impl<W: HasRawWindowHandle> AsRef<W> for GraphicsContext<W> {
+    /// Equivalent to [`self.window()`](Self::window()).
+    fn as_ref(&self) -> &W {
+        self.window()
+    }
+}
+
 trait GraphicsContextImpl {
     unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16);
 }


### PR DESCRIPTION
This will allow code which works with windows generically (such as an event loop which can work with `softbuffer` or another graphics library) to be able to access the underlying window without knowing about `softbuffer` in particular.