### PR TITLE
Apply rustfmt and other formatting tweaks.

### DIFF
--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -1,8 +1,8 @@
-use std::f64::consts::PI;
 use instant::Instant;
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 use softbuffer::GraphicsContext;
+use std::f64::consts::PI;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
@@ -42,12 +42,12 @@ fn main() {
                     (size.width, size.height)
                 };
 
-                if (width, height) != old_size{
+                if (width, height) != old_size {
                     old_size = (width, height);
                     frames = pre_render_frames(width as usize, height as usize);
                 };
 
-                let buffer = &frames[((elapsed*60.0).round() as usize).clamp(0, 59)];
+                let buffer = &frames[((elapsed * 60.0).round() as usize).clamp(0, 59)];
                 graphics_context.set_buffer(buffer.as_slice(), width as u16, height as u16);
             }
             Event::MainEventsCleared => {
@@ -64,16 +64,19 @@ fn main() {
     });
 }
 
-fn pre_render_frames(width: usize, height: usize) -> Vec<Vec<u32>>{
-    let render = |frame_id|{
-        let elapsed = ((frame_id as f64)/(60.0))*2.0*PI;
+fn pre_render_frames(width: usize, height: usize) -> Vec<Vec<u32>> {
+    let render = |frame_id| {
+        let elapsed = ((frame_id as f64) / (60.0)) * 2.0 * PI;
         let buffer = (0..((width * height) as usize))
             .map(|index| {
-                let y = ((index / (width as usize)) as f64)/(height as f64);
-                let x = ((index % (width as usize)) as f64)/(width as f64);
-                let red = ((((y + elapsed).sin()*0.5+0.5)*255.0).round() as u32).clamp(0, 255);
-                let green = ((((x + elapsed).sin()*0.5+0.5)*255.0).round() as u32).clamp(0, 255);
-                let blue = ((((y - elapsed).cos()*0.5+0.5)*255.0).round() as u32).clamp(0, 255);
+                let y = ((index / (width as usize)) as f64) / (height as f64);
+                let x = ((index % (width as usize)) as f64) / (width as f64);
+                let red =
+                    ((((y + elapsed).sin() * 0.5 + 0.5) * 255.0).round() as u32).clamp(0, 255);
+                let green =
+                    ((((x + elapsed).sin() * 0.5 + 0.5) * 255.0).round() as u32).clamp(0, 255);
+                let blue =
+                    ((((y - elapsed).cos() * 0.5 + 0.5) * 255.0).round() as u32).clamp(0, 255);
 
                 let color = blue | (green << 8) | (red << 16);
 

--- a/examples/fruit.rs
+++ b/examples/fruit.rs
@@ -7,13 +7,16 @@ use winit::window::WindowBuilder;
 fn main() {
     //see fruit.jpg.license for the license of fruit.jpg
     let fruit = image::load_from_memory(include_bytes!("fruit.jpg")).unwrap();
-    let buffer = fruit.pixels().map(|(_x, _y, pixel)|{
-        let red = pixel.0[0] as u32;
-        let green = pixel.0[1] as u32;
-        let blue = pixel.0[2] as u32;
+    let buffer = fruit
+        .pixels()
+        .map(|(_x, _y, pixel)| {
+            let red = pixel.0[0] as u32;
+            let green = pixel.0[1] as u32;
+            let blue = pixel.0[2] as u32;
 
-        blue | (green << 8) | (red << 16)
-    }).collect::<Vec<_>>();
+            blue | (green << 8) | (red << 16)
+        })
+        .collect::<Vec<_>>();
 
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new().build(&event_loop).unwrap();

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -1,12 +1,14 @@
 use crate::{GraphicsContextImpl, SoftBufferError};
-use raw_window_handle::{HasRawWindowHandle, AppKitHandle};
-use core_graphics::base::{kCGBitmapByteOrder32Little, kCGImageAlphaNoneSkipFirst, kCGRenderingIntentDefault};
+use core_graphics::base::{
+    kCGBitmapByteOrder32Little, kCGImageAlphaNoneSkipFirst, kCGRenderingIntentDefault,
+};
 use core_graphics::color_space::CGColorSpace;
 use core_graphics::data_provider::CGDataProvider;
 use core_graphics::image::CGImage;
+use raw_window_handle::{AppKitHandle, HasRawWindowHandle};
 
+use cocoa::appkit::{NSView, NSViewHeightSizable, NSViewWidthSizable};
 use cocoa::base::{id, nil};
-use cocoa::appkit::{NSView, NSViewWidthSizable, NSViewHeightSizable};
 use cocoa::quartzcore::{CALayer, ContentsGravity};
 use foreign_types::ForeignType;
 
@@ -17,7 +19,9 @@ pub struct CGImpl {
 }
 
 impl CGImpl {
-    pub unsafe fn new<W: HasRawWindowHandle>(handle: AppKitHandle) -> Result<Self, SoftBufferError<W>> {
+    pub unsafe fn new<W: HasRawWindowHandle>(
+        handle: AppKitHandle,
+    ) -> Result<Self, SoftBufferError<W>> {
         let view = handle.ns_view as id;
         let layer = CALayer::new();
         let subview: id = NSView::alloc(nil).initWithFrame_(view.frame());
@@ -28,16 +32,15 @@ impl CGImpl {
 
         view.addSubview_(subview); // retains subview (+1) = 2
         let _: () = msg_send![subview, release]; // releases subview (-1) = 1
-        Ok(Self{layer})
+        Ok(Self { layer })
     }
 }
 
 impl GraphicsContextImpl for CGImpl {
     unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
         let color_space = CGColorSpace::create_device_rgb();
-        let data = std::slice::from_raw_parts(
-            buffer.as_ptr() as *const u8,
-            buffer.len() * 4).to_vec();
+        let data =
+            std::slice::from_raw_parts(buffer.as_ptr() as *const u8, buffer.len() * 4).to_vec();
         let data_provider = CGDataProvider::from_buffer(Arc::new(data));
         let image = CGImage::new(
             width as usize,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
-use std::error::Error;
 use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use std::error::Error;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -13,13 +13,19 @@ pub enum SoftBufferError<W: HasRawWindowHandle> {
         handle: RawWindowHandle,
     },
     #[error("Platform error")]
-    PlatformError(Option<String>, Option<Box<dyn Error>>)
+    PlatformError(Option<String>, Option<Box<dyn Error>>),
 }
 
 #[allow(unused)] // This isn't used on all platforms
-pub(crate) fn unwrap<T, E: std::error::Error + 'static, W: HasRawWindowHandle>(res: Result<T, E>, str: &str) -> Result<T, SoftBufferError<W>>{
-    match res{
+pub(crate) fn unwrap<T, E: std::error::Error + 'static, W: HasRawWindowHandle>(
+    res: Result<T, E>,
+    str: &str,
+) -> Result<T, SoftBufferError<W>> {
+    match res {
         Ok(t) => Ok(t),
-        Err(e) => Err(SoftBufferError::PlatformError(Some(str.into()), Some(Box::new(e))))
+        Err(e) => Err(SoftBufferError::PlatformError(
+            Some(str.into()),
+            Some(Box::new(e)),
+        )),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,16 +82,16 @@ impl<W: HasRawWindowHandle> GraphicsContext<W> {
 
     /// Shows the given buffer with the given width and height on the window corresponding to this
     /// graphics context. Panics if buffer.len() ≠ width*height. If the size of the buffer does
-    /// not match the size of the window, the buffer is drawn in the upper-left corner of the window.
-    /// It is recommended in most production use cases to have the buffer fill the entire window.
-    /// Use your windowing library to find the size of the window.
+    /// not match the size of the window, the buffer is drawn in the upper-left corner of the
+    /// window. It is recommended in most production use cases to have the buffer fill the entire
+    /// window. Use your windowing library to find the size of the window.
     ///
     /// The format of the buffer is as follows. There is one u32 in the buffer for each pixel in
-    /// the area to draw. The first entry is the upper-left most pixel. The second is one to the right
-    /// etc. (Row-major top to bottom left to right one u32 per pixel). Within each u32 the highest
-    /// order 8 bits are to be set to 0. The next highest order 8 bits are the red channel, then the
-    /// green channel, and then the blue channel in the lowest-order 8 bits. See the examples for
-    /// one way to build this format using bitwise operations.
+    /// the area to draw. The first entry is the upper-left most pixel. The second is one to the
+    /// right etc. (Row-major top to bottom left to right one u32 per pixel). Within each u32 the
+    /// highest order 8 bits are to be set to 0. The next highest order 8 bits are the red channel,
+    /// then the green channel, and then the blue channel in the lowest-order 8 bits. See the
+    /// examples for one way to build this format using bitwise operations.
     ///
     /// --------
     ///
@@ -106,7 +106,10 @@ impl<W: HasRawWindowHandle> GraphicsContext<W> {
     #[inline]
     pub fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
         if (width as usize) * (height as usize) != buffer.len() {
-            panic!("The size of the passed buffer is not the correct size. Its length must be exactly width*height.");
+            panic!(
+                "The size of the passed buffer is not the correct size. \
+                Its length must be exactly width*height."
+            );
         }
 
         unsafe {
@@ -130,6 +133,8 @@ fn window_handle_type_name(handle: &RawWindowHandle) -> &'static str {
         RawWindowHandle::AppKit(_) => "AppKit",
         RawWindowHandle::Orbital(_) => "Orbital",
         RawWindowHandle::UiKit(_) => "UiKit",
-        _ => "Unknown Name", //don't completely fail to compile if there is a new raw window handle type that's added at some point
+        // Don't completely fail to compile if there is a new raw window handle type that's added at
+        // some point.
+        _ => "Unknown Name",
     }
 }

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -1,68 +1,102 @@
+use crate::{error::unwrap, GraphicsContextImpl, SoftBufferError};
 use raw_window_handle::{HasRawWindowHandle, WaylandHandle};
+use std::{
+    fs::File,
+    io::Write,
+    os::unix::prelude::{AsRawFd, FileExt},
+};
 use tempfile::tempfile;
-use wayland_client::{Display, sys::client::wl_display, GlobalManager, protocol::{wl_shm::WlShm, wl_buffer::WlBuffer, wl_surface::WlSurface}, Main, Proxy, EventQueue};
-use crate::{GraphicsContextImpl, SoftBufferError, error::unwrap};
-use std::{fs::File, os::unix::prelude::{AsRawFd, FileExt}, io::Write};
+use wayland_client::{
+    protocol::{wl_buffer::WlBuffer, wl_shm::WlShm, wl_surface::WlSurface},
+    sys::client::wl_display,
+    Display, EventQueue, GlobalManager, Main, Proxy,
+};
 
 pub struct WaylandImpl {
     _event_queue: EventQueue,
     surface: WlSurface,
     shm: Main<WlShm>,
     tempfile: File,
-    buffer: Option<WaylandBuffer>
+    buffer: Option<WaylandBuffer>,
 }
 
-struct WaylandBuffer{
+struct WaylandBuffer {
     width: i32,
     height: i32,
-    buffer: Main<WlBuffer>
+    buffer: Main<WlBuffer>,
 }
 
 impl WaylandImpl {
-
-    pub unsafe fn new<W: HasRawWindowHandle>(handle: WaylandHandle) -> Result<Self, SoftBufferError<W>> {
+    pub unsafe fn new<W: HasRawWindowHandle>(
+        handle: WaylandHandle,
+    ) -> Result<Self, SoftBufferError<W>> {
         let display = Display::from_external_display(handle.display as *mut wl_display);
         let mut event_queue = display.create_event_queue();
         let attached_display = (*display).clone().attach(event_queue.token());
         let globals = GlobalManager::new(&attached_display);
-        unwrap(event_queue.sync_roundtrip(&mut (), |_, _, _| unreachable!()), "Failed to make round trip to server")?;
-        let shm = unwrap(globals.instantiate_exact::<WlShm>(1), "Failed to instantiate Wayland Shm")?;
-        let tempfile = unwrap(tempfile(), "Failed to create temporary file to store buffer.")?;
+        unwrap(
+            event_queue.sync_roundtrip(&mut (), |_, _, _| unreachable!()),
+            "Failed to make round trip to server",
+        )?;
+        let shm = unwrap(
+            globals.instantiate_exact::<WlShm>(1),
+            "Failed to instantiate Wayland Shm",
+        )?;
+        let tempfile = unwrap(
+            tempfile(),
+            "Failed to create temporary file to store buffer.",
+        )?;
         let surface = Proxy::from_c_ptr(handle.surface as _).into();
-        Ok(Self{
+        Ok(Self {
             _event_queue: event_queue,
-            surface, shm, tempfile,
-            buffer: None
+            surface,
+            shm,
+            tempfile,
+            buffer: None,
         })
     }
 
-    fn ensure_buffer_size(&mut self, width: i32, height: i32){
-        if !self.check_buffer_size_equals(width, height){
-            let pool = self.shm.create_pool(self.tempfile.as_raw_fd(), width*height*4);
-            let buffer = pool.create_buffer(0, width, height, width*4, wayland_client::protocol::wl_shm::Format::Xrgb8888);
-            self.buffer = Some(WaylandBuffer{
+    fn ensure_buffer_size(&mut self, width: i32, height: i32) {
+        if !self.check_buffer_size_equals(width, height) {
+            let pool = self
+                .shm
+                .create_pool(self.tempfile.as_raw_fd(), width * height * 4);
+            let buffer = pool.create_buffer(
+                0,
                 width,
                 height,
-                buffer
+                width * 4,
+                wayland_client::protocol::wl_shm::Format::Xrgb8888,
+            );
+            self.buffer = Some(WaylandBuffer {
+                width,
+                height,
+                buffer,
             });
         }
     }
 
-    fn check_buffer_size_equals(&self, width: i32, height: i32) -> bool{
-        match &self.buffer{
+    fn check_buffer_size_equals(&self, width: i32, height: i32) -> bool {
+        match &self.buffer {
             Some(buffer) => buffer.width == width && buffer.height == height,
-            None => false
+            None => false,
         }
     }
-
 }
 
 impl GraphicsContextImpl for WaylandImpl {
     unsafe fn set_buffer(&mut self, buffer: &[u32], width: u16, height: u16) {
         self.ensure_buffer_size(width as i32, height as i32);
         let wayland_buffer = self.buffer.as_mut().unwrap();
-        self.tempfile.write_at(std::slice::from_raw_parts(buffer.as_ptr() as *const u8, buffer.len()*4), 0).expect("Failed to write buffer to temporary file.");
-        self.tempfile.flush().expect("Failed to flush buffer to temporary file.");
+        self.tempfile
+            .write_at(
+                std::slice::from_raw_parts(buffer.as_ptr() as *const u8, buffer.len() * 4),
+                0,
+            )
+            .expect("Failed to write buffer to temporary file.");
+        self.tempfile
+            .flush()
+            .expect("Failed to flush buffer to temporary file.");
         self.surface.attach(Some(&wayland_buffer.buffer), 0, 0);
         self.surface.commit();
     }

--- a/src/web.rs
+++ b/src/web.rs
@@ -43,21 +43,25 @@ impl WebImpl {
             .unchecked_into();
 
         let ctx = canvas
-        .get_context("2d")
-        .map_err(|_| {
-            SoftBufferError::PlatformError(
-                Some("Canvas already controlled using `OffscreenCanvas`".into()),
-                None,
-            )
-        })?
-        .ok_or_else(|| {
-            SoftBufferError::PlatformError(
-                Some("A canvas context other than `CanvasRenderingContext2d` was already created".into()),
-                None,
-            )
-        })?
-        .dyn_into()
-        .expect("`getContext(\"2d\") didn't return a `CanvasRenderingContext2d`");
+            .get_context("2d")
+            .map_err(|_| {
+                SoftBufferError::PlatformError(
+                    Some("Canvas already controlled using `OffscreenCanvas`".into()),
+                    None,
+                )
+            })?
+            .ok_or_else(|| {
+                SoftBufferError::PlatformError(
+                    Some(
+                        "A canvas context other than `CanvasRenderingContext2d` \
+                        was already created"
+                            .into(),
+                    ),
+                    None,
+                )
+            })?
+            .dyn_into()
+            .expect("`getContext(\"2d\") didn't return a `CanvasRenderingContext2d`");
 
         Ok(Self { canvas, ctx })
     }
@@ -74,7 +78,8 @@ impl GraphicsContextImpl for WebImpl {
             .flat_map(|pixel| [(pixel >> 16) as u8, (pixel >> 8) as u8, pixel as u8, 255])
             .collect();
 
-        // This should only throw an error if the buffer we pass's size is incorrect, which is checked in the outer `set_buffer` call.
+        // This should only throw an error if the buffer we pass's size is incorrect,
+        // which is checked in the outer `set_buffer` call.
         let image_data =
             ImageData::new_with_u8_clamped_array(Clamped(&bitmap), width.into()).unwrap();
 

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -19,19 +19,22 @@ struct BitmapInfo {
 }
 
 impl Win32Impl {
-    pub unsafe fn new<W: HasRawWindowHandle>(handle: &Win32Handle) -> Result<Self, crate::SoftBufferError<W>> {
+    pub unsafe fn new<W: HasRawWindowHandle>(
+        handle: &Win32Handle,
+    ) -> Result<Self, crate::SoftBufferError<W>> {
         let dc = GetDC(handle.hwnd as HWND);
 
-        if dc.is_null(){
-            return Err(SoftBufferError::PlatformError(Some("Device Context is null".into()), None));
+        if dc.is_null() {
+            return Err(SoftBufferError::PlatformError(
+                Some("Device Context is null".into()),
+                None,
+            ));
         }
 
-        Ok(
-            Self {
-                dc,
-                window: handle.hwnd as HWND,
-            }
-        )
+        Ok(Self {
+            dc,
+            window: handle.hwnd as HWND,
+        })
     }
 }
 

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -12,25 +12,30 @@ pub struct X11Impl {
 }
 
 impl X11Impl {
-    pub unsafe fn new<W: HasRawWindowHandle>(handle: XlibHandle) -> Result<Self, SoftBufferError<W>> {
+    pub unsafe fn new<W: HasRawWindowHandle>(
+        handle: XlibHandle,
+    ) -> Result<Self, SoftBufferError<W>> {
         let lib = match Xlib::open() {
             Ok(lib) => lib,
-            Err(e) => return Err(SoftBufferError::PlatformError(Some("Failed to open Xlib".into()), Some(Box::new(e))))
+            Err(e) => {
+                return Err(SoftBufferError::PlatformError(
+                    Some("Failed to open Xlib".into()),
+                    Some(Box::new(e)),
+                ))
+            }
         };
         let screen = (lib.XDefaultScreen)(handle.display as *mut Display);
         let gc = (lib.XDefaultGC)(handle.display as *mut Display, screen);
         let visual = (lib.XDefaultVisual)(handle.display as *mut Display, screen);
         let depth = (lib.XDefaultDepth)(handle.display as *mut Display, screen);
 
-        Ok(
-            Self {
-                handle,
-                lib,
-                gc,
-                visual,
-                depth,
-            }
-        )
+        Ok(Self {
+            handle,
+            lib,
+            gc,
+            visual,
+            depth,
+        })
     }
 }
 


### PR DESCRIPTION
I don't know if this change is welcome, but when I noticed format-on-save in my editor changing some existing formatting, I figured it's worth checking.

There are two commits in this PR:

* The first one merely applies `cargo fmt`. I reviewed the results to verify that readability was not harmed; the only thing I noticed that might be undesirable was `std` imports getting sorted alphabetically in their group. This could be fixed by inserting a blank line.

* The second one rewraps comments and string literals so that they fit in the standard 100-column line length. (`rustfmt` skips formatting lines that contain such literals and comments, so this is helpful for ensuring standard formatting of the code surrounding them.)
