### PR TITLE
Enable needed features of winapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ tempfile = "3.3.0"
 wayland-client = {version = "0.29", features = ["use_system_lib"], default_features = false}
 x11-dl = "2.19.1"
 
-[target.'cfg(target_os = "windows")'.dependencies]
-winapi = "0.3.9"
+[target.'cfg(target_os = "windows")'.dependencies.winapi]
+version = "0.3.9"
+features = ["windef", "wingdi", "winuser"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.24.0"


### PR DESCRIPTION
Previously, `softbuffer` wouldn't successfully build on its own on Windows; the examples only worked because dependencies happened to enable the needed features.