### PR TITLE
Update raw_window_handle to 0.5 and winit to 0.27.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["examples"]
 
 [dependencies]
 thiserror = "1.0.30"
-raw-window-handle = "0.4.2"
+raw-window-handle = "0.5.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 tempfile = "3.3.0"
@@ -40,7 +40,7 @@ features = ["CanvasRenderingContext2d", "Document", "Element", "HtmlCanvasElemen
 
 [dev-dependencies]
 instant = "0.1.12"
-winit = "0.26.1"
+winit = "0.27.1"
 
 [dev-dependencies.image]
 version = "0.23.14"

--- a/src/cg.rs
+++ b/src/cg.rs
@@ -1,5 +1,5 @@
 use crate::{GraphicsContextImpl, SoftBufferError};
-use raw_window_handle::{HasRawWindowHandle, AppKitHandle};
+use raw_window_handle::{HasRawWindowHandle, AppKitWindowHandle};
 use core_graphics::base::{kCGBitmapByteOrder32Little, kCGImageAlphaNoneSkipFirst, kCGRenderingIntentDefault};
 use core_graphics::color_space::CGColorSpace;
 use core_graphics::data_provider::CGDataProvider;
@@ -17,7 +17,7 @@ pub struct CGImpl {
 }
 
 impl CGImpl {
-    pub unsafe fn new<W: HasRawWindowHandle>(handle: AppKitHandle) -> Result<Self, SoftBufferError<W>> {
+    pub unsafe fn new<W: HasRawWindowHandle>(handle: AppKitWindowHandle) -> Result<Self, SoftBufferError<W>> {
         let view = handle.ns_view as id;
         let layer = CALayer::new();
         let subview: id = NSView::alloc(nil).initWithFrame_(view.frame());


### PR DESCRIPTION
To work with winit 0.27, raw_window_handle needs to be updated to 0.5. I've tested the examples, they all still run successfully on my mac.